### PR TITLE
fix: add esfera on context to use in text infos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Etapa 1: Build da aplicação
+FROM node:22 AS build
+
+# Defina o diretório de trabalho no contêiner
+WORKDIR /app
+
+# Copie os arquivos de configuração do projeto para o contêiner
+COPY package*.json ./
+
+# Instale as dependências da aplicação
+RUN npm install
+
+# Copie o restante dos arquivos da aplicação para o contêiner
+COPY . .
+
+# Rode o build da aplicação para produção
+RUN npm run build
+
+# Etapa 2: Servir a aplicação em um ambiente de produção
+FROM node:22 AS production
+
+# Defina o diretório de trabalho no contêiner
+WORKDIR /app
+
+# Instale apenas as dependências de produção
+COPY package*.json ./
+RUN npm install --only=production
+
+# Copie os arquivos de build da etapa anterior
+COPY --from=build /app/dist ./dist
+
+# Exponha a porta onde a aplicação vai rodar
+EXPOSE 3000
+
+# Comando para rodar o servidor (por exemplo, usando uma ferramenta como serve ou http-server)
+CMD ["npx", "serve", "dist", "-l", "3000"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
-    "rlayers": "^2.3.1"
+    "rlayers": "^2.3.1",
+    "serve": "^14.2.3"
   },
   "devDependencies": {
     "@tanstack/router-devtools": "^1.22.2",

--- a/src/assets/data/entenda.json
+++ b/src/assets/data/entenda.json
@@ -32,7 +32,7 @@
         {
             "header": {
                 "title": "Alerta mensal de desmatamento",
-                "description": "No mês de {{ultimoMes}} foram desmatados **{{alertaMensalDesmatamentoUltimoMesHa}}** hectares.",
+                "description": "No mês de {{ultimoMes}} foram desmatados **{{alertaMensalDesmatamentoUltimoMesHa}}** hectares em FPND {{esfera}}.",
                 "icon": "alertaMensalDeDesmatamento"
             },
             "body": [
@@ -49,7 +49,7 @@
         {
             "header": {
                 "title": "Desmatamento",
-                "description": "A área desmatada total nas FPND n{{recortePrefixo}} {{recorteNome}} é de **{{desmatamentoAreaHa}}** de hectares",
+                "description": "A área desmatada total nas FPND {{esfera}} n{{recortePrefixo}} {{recorteNome}} é de **{{desmatamentoAreaHa}}** de hectares",
                 "icon": "desmatamento"
             },
             "body": [
@@ -72,7 +72,7 @@
         {
             "header": {
                 "title": "Estoque de carbono",
-                "description": "A FPND federal n{{recortePrefixo}} {{recorteNome}} estoca **{{estoqueCarbonoTon}}** de toneladas de carbono.",
+                "description": "As FPND {{esfera}} n{{recortePrefixo}} {{recorteNome}} estocam **{{estoqueCarbonoTon}}** de toneladas de carbono.",
                 "icon": "estoqueDeCarbono"
             },
             "body": [
@@ -86,7 +86,7 @@
         {
             "header": {
                 "title": "Biodiversidade",
-                "description": "As FPND federais n{{recortePrefixo}} **{{recorteNome}}** abrigam em média **{{biodiversidadeFpndFederalMedia}}** espécies ameaçadas da fauna e flora amazônica.",
+                "description": "As FPND {{esfera}} n{{recortePrefixo}} **{{recorteNome}}** abrigam em média **{{biodiversidadeFpndFederalMedia}}** espécies ameaçadas da fauna e flora amazônica.",
                 "icon": "biodiversidade"
             },
             "body": [
@@ -100,7 +100,7 @@
         {
             "header": {
                 "title": "CAR (Cadastro Ambiental Rural)",
-                "description": "Há **{{carSobreposicaoFpndAreaHa}}** de hectares  de Cadastro Ambiental Rural (CAR), **irregulares**, sobrepostos em Florestas Públicas Não Destinadas.",
+                "description": "Há **{{carSobreposicaoFpndAreaHa}}** de hectares de Cadastro Ambiental Rural (CAR), **irregulares**, sobrepostos em FPND {{esfera}} no estado.",
                 "icon": "car"
             },
             "body": [

--- a/src/components/molecules/FPNDLayer.tsx
+++ b/src/components/molecules/FPNDLayer.tsx
@@ -93,7 +93,7 @@ export const FPNDLayer: FC<FPNDLayerProps> = ({ mapData, camada, esfera, estados
     }, [camada, esfera, estados, selectedFeatureCode]);
     
     useEffect(() => {
-        navigate({ search: (prev) => ({ ...prev, fpnd: selectedFeatureCode || undefined }) });
+        navigate({ search: (prev: any) => ({ ...prev, fpnd: selectedFeatureCode || undefined }) } as any);
     }, [selectedFeatureCode]);
 
     useEffect(() => {

--- a/src/components/organisms/Mapa.tsx
+++ b/src/components/organisms/Mapa.tsx
@@ -48,11 +48,13 @@ export const Mapa = () => {
         setMapCenter,
         setMapZoom,
     } = useBusiness()
+    
+    // esfera - define se o contexto do mapa e dos dados (0 - Estadual ou 1 - Federal)
     const { camada, esfera, estados } = useSearch({ from: '/' })
     const mapRef = useRef<any>(null)
     const legendData = camada!==undefined && mapData?.layersLegends ? mapData?.layersLegends[Camadas[camada]] : defaultLegend
     const [ pixelClicked, setPixelClicked ] = useState<Pixel | null> (null)
-    
+
     useEffect(() => {
         if (mapRef.current ) {
             let extent;

--- a/src/services/data/info.ts
+++ b/src/services/data/info.ts
@@ -14,7 +14,9 @@ export const getInfoData = async (camada: number | undefined, esfera: number | u
         console.log(_url)
         const res = await axios.get(_url)
         if (!res?.data) throw ('No data')
-        return _formatData(res.data)
+        
+        // Adiciona o contexto de esfera (0 - Estaduais, 1 - Federais) aos dados para serem apresentados junto aos textos informativos
+        return _formatData({ ...res.data, esfera: esfera === 0 ? "estaduais" : esfera === 1 ? "federais" : "" })
     } catch (error) {
         return undefined
     }


### PR DESCRIPTION
**Contexto**
Adiciona informação sobre a esfera (Estaduais e Federais) aos textos explicativos no canto direito do Mapa.

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/d1a324b0-5be3-400b-af79-2dc1c4881937">
