### PR TITLE
Fixed the 'extent' transformation on the map to ensure valid coordinates

### DIFF
--- a/src/components/organisms/Mapa.tsx
+++ b/src/components/organisms/Mapa.tsx
@@ -88,6 +88,7 @@ export const Mapa = () => {
         extent = estados.reduce((acc, uf) => {
           //@ts-ignore
           const ufExtent = extents[uf] || extents["default"];
+
           if (!acc) return ufExtent;
           return [
             Math.min(acc[0], ufExtent[0]), // xmin
@@ -97,15 +98,24 @@ export const Mapa = () => {
           ];
         }, []);
       } else {
-        // Usa o extent default
         extent = extents["default"];
       }
-      //@ts-ignore
-      extent = [
-        ...fromLonLat([extent[0], extent[1]]),
-        ...fromLonLat([extent[2], extent[3]]),
+
+      if (
+        !extent ||
+        extent.length !== 4 ||
+        extent.some((value) => isNaN(value) || value === undefined)
+      ) {
+        return;  // Evita tentar transformar um extent inválido
+      }
+  
+      // Garantir que a ordem das coordenadas está correta: [longitude, latitude]
+      const transformedExtent = [
+        ...fromLonLat([extent[0], extent[1]]), // [longitude, latitude]
+        ...fromLonLat([extent[2], extent[3]]), // [longitude, latitude]
       ];
-      mapRef.current.ol.getView().fit(extent, mapRef.current.ol.getSize());
+
+      mapRef.current.ol.getView().fit(transformedExtent, mapRef.current.ol.getSize());
     }
   }, [mapRef, estados]);
 


### PR DESCRIPTION
## Contexto
Ao filtrar um ou mais estados na visualização do mapa do observatório todo o componente do mapa está sendo ocultado.
- Tarefa: [Problema no filtro de território no mapa da APD](https://app.asana.com/0/1161468210277385/1208974361932083/f)
<img width="900" alt="Captura de Tela 2024-12-13 às 17 45 22" src="https://github.com/user-attachments/assets/c605bb09-ef48-4315-98cf-745846895a45" />

## Solução
A correção garante o cálculo e a transformação adequados do "extent" (caixa delimitadora) do mapa, validando as coordenadas antes de aplicar a transformação. Isso evita problemas em que coordenadas inválidas ou indefinidas causavam erros ao renderi
<img width="844" alt="Captura de Tela 2024-12-16 às 17 53 14" src="https://github.com/user-attachments/assets/f3abf41d-153f-4f03-9a00-ad7d59de50f7" />
zar o mapa. 
